### PR TITLE
AgreementsEndpoint requires a public constructor for DI to work.

### DIFF
--- a/src/Nordigen.Net/Internal/AgreementsEndpoint.cs
+++ b/src/Nordigen.Net/Internal/AgreementsEndpoint.cs
@@ -11,7 +11,7 @@ internal class AgreementsEndpoint : IAgreementsEndpoint, IEndpoint
 {
     private readonly INordigenHttpClient _client;
 
-    internal AgreementsEndpoint(INordigenHttpClient client)
+    public AgreementsEndpoint(INordigenHttpClient client)
     {
         _client = client;
     }


### PR DESCRIPTION
I found that unless you make the constructor for AgreementsEndpoint public the DI fails.