### PR TITLE
add RemittanceInformationUnstructuredArray to Transaction

### DIFF
--- a/src/Nordigen.Net/Responses/Transaction.cs
+++ b/src/Nordigen.Net/Responses/Transaction.cs
@@ -29,7 +29,8 @@ public class Transaction
         DateTime? valueDateTime,
         string? remittanceInformationUnstructured,
         string? additionalInformation,
-        string? remittanceInformationStructured)
+        string? remittanceInformationStructured,
+        string[]? remittanceInformationUnstructuredArray)
     {
         TransactionId = transactionId;
         BankTransactionCode = bankTransactionCode;
@@ -54,6 +55,7 @@ public class Transaction
         RemittanceInformationUnstructured = remittanceInformationUnstructured;
         AdditionalInformation = additionalInformation;
         RemittanceInformationStructured = remittanceInformationStructured;
+        RemittanceInformationUnstructuredArray = remittanceInformationUnstructuredArray;
     }
     public string? TransactionId { get; }
     public string? BankTransactionCode { get; }
@@ -82,4 +84,5 @@ public class Transaction
     public string? RemittanceInformationUnstructured { get; }
     public string? AdditionalInformation { get; }
     public string? RemittanceInformationStructured { get; } 
+    public string[]? RemittanceInformationUnstructuredArray { get; } 
 }

--- a/tests/Nordigen.Net.UnitTests/AccountsEndpointTests.cs
+++ b/tests/Nordigen.Net.UnitTests/AccountsEndpointTests.cs
@@ -200,4 +200,15 @@ public class AccountsEndpointTests
 
         result.AsT0.Should().BeEquivalentTo(expected);
     }
+
+    [Fact]
+    public  void Transactions_When_Valid_Information_Deserialize_Correctly()
+    {
+        const string payload =
+            "{\"booked\": [{\"transactionId\": \"string\",\"debtorName\": \"string\",\"debtorAccount\": {\"iban\": \"string\"},\"transactionAmount\": {\"currency\": \"string\",\"amount\": \"855.51\"},\"bankTransactionCode\": \"string\",\"bookingDate\": \"2022-01-23\",\"valueDate\": \"2022-01-19\",\"remittanceInformationUnstructured\": \"string\",\"remittanceInformationUnstructuredArray\": [\"string1\", \"string2\"]},{\"transactionId\": \"string\",\"transactionAmount\": {\"currency\": \"string\",\"amount\": \"-891.75\"},\"bankTransactionCode\": \"string\",\"bookingDate\": \"2022-01-23\",\"valueDate\": \"2022-01-21\",\"remittanceInformationUnstructured\": \"string\"}],\"pending\": [{\"transactionAmount\": {\"currency\": \"string\",\"amount\": \"423.35\"},\"valueDate\": \"2022-01-18\",\"remittanceInformationUnstructured\": \"string\"}]}";
+            
+        var expected = _serializer.Deserialize<Transactions>(payload);
+
+        expected.Booked.First().RemittanceInformationUnstructuredArray.Should().HaveCount(2);
+    }
 }


### PR DESCRIPTION
There is a new RemittanceInformationUnstructuredArray field in the Transaction API Response from `/api/v2/accounts/:id/transactions/`.

I added the mapping for the field and a Unit Test for the deserialization.